### PR TITLE
remove blog posts except material ui

### DIFF
--- a/blog/2023-06-11-astro-rss-images/index.mdx
+++ b/blog/2023-06-11-astro-rss-images/index.mdx
@@ -5,6 +5,7 @@ description: Guide on adding post main images to your rss feed for use in Mailer
 authors: [Reaper]
 # image: https://raw.githubusercontent.com/Boston343/web-dev-docs/main/blog/2023-01-07-materialui-with-docusaurus/materialui-with-docusaurus.jpg
 tags: [astro, rss, mailerlite]
+draft: true
 ---
 
 Want to add an image to your RSS feed blog posts to integrate with something like MailerLite? Here I'll go through how to do this on an Astro site, although similar concepts will apply for any rss feed. You can do this using the integration `@astrojs/rss`. the Astro RSS docs can be found [here](https://docs.astro.build/en/guides/rss/).

--- a/blog/2023-06-21-astro-ga4/index.mdx
+++ b/blog/2023-06-21-astro-ga4/index.mdx
@@ -5,6 +5,7 @@ description: Guide on adding Google Tag Manager and Google Analytics 4 (GA4) to 
 authors: [Reaper]
 image: https://raw.githubusercontent.com/Boston343/web-dev-docs/main/blog/2023-06-21-astro-ga4/astro-ga4-google-tag-manager.jpeg
 tags: [astro, ga4, gtm, google]
+draft: true
 ---
 
 import mainImage from "./astro-ga4-google-tag-manager.jpeg";

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -11,7 +11,7 @@ require("dotenv").config();
 const config = {
   title: "Web Reaper Docs",
   tagline: "Quick reference for web development tips, tools, and techniques.",
-  url: "https://webreaper.dev",
+  url: "https://docs.webreaper.dev",
   baseUrl: "/",
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -209,10 +209,10 @@ const config = {
           {
             title: "Blog",
             items: [
-              {
-                label: "Astro RSS Feed Blog Post Images",
-                href: "/blog/astro-rss-feed-blog-post-images/",
-              },
+              // {
+              //   label: "Astro RSS Feed Blog Post Images",
+              //   href: "/blog/astro-rss-feed-blog-post-images/",
+              // },
               {
                 label: "Material UI with Docusaurus",
                 href: "/blog/material-ui-theme-with-docusaurus/",


### PR DESCRIPTION
Most blog posts now live at [webreaper.dev](https://webreaper.dev/posts/) 